### PR TITLE
Remove erroneous href

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         |
         <a href="https://www.github.com/intermezzos">GitHub</a>
         |
-        <a href=href="https://webchat.freenode.net/#intermezzos">IRC Freenode</a>
+        <a href="https://webchat.freenode.net/#intermezzos">IRC Freenode</a>
         |
         <a href="mailto:steve@steveklabnik.com">Contact</a>
         |


### PR DESCRIPTION
In the link to the FreeNode IRC channel a double href was present.
