### PR TITLE
fix(a11y): increase contrast on elements

### DIFF
--- a/public/styles/custom.css
+++ b/public/styles/custom.css
@@ -29,7 +29,11 @@ img {
 }
 
 a {
-    color: #0080a4;
+    color: #400AA7;
+}
+
+a:hover {
+    color: #0c0221;
 }
 
 .subtitle {
@@ -41,13 +45,13 @@ a {
 }
 
 .button.button-primary {
-    background: #0081a1;
-    border: #0081a1;
+    background: #400AA7;
+    border: #400AA7;
 }
 
 .button.button-primary:hover {
-    background: #006683;
-    border: #006683;
+    background: #260664;
+    border: #260664;
 }
 
 .footer {

--- a/public/styles/custom.css
+++ b/public/styles/custom.css
@@ -28,14 +28,32 @@ img {
     width: 100%;
 }
 
+a {
+    color: #0080a4;
+}
+
 .subtitle {
-  color: #999;
+  color: #949494;
 }
 
 .center {
   text-align: center; 
 }
 
+.button.button-primary {
+    background: #0081a1;
+    border: #0081a1;
+}
+
+.button.button-primary:hover {
+    background: #006683;
+    border: #006683;
+}
+
 .footer {
   padding: 20px 0;
+}
+
+.footer .subtitle {
+    color: #767676;
 }


### PR DESCRIPTION
:wave:

Hey @steveklabnik, thanks for introducing me to intermezzOS, this looks so cool. Also hi, @ashleygwilliams :)

I noticed that there were a few contrasting problems on the website:

<img width="1132" alt="intermezzos_before" src="https://cloud.githubusercontent.com/assets/542140/12066542/53e20ae2-afe1-11e5-9fec-2da8666cdbd0.png">

(Analysed using [totally.js](http://khan.github.io/tota11y/))

So I updated some of the colours:

<img width="918" alt="intermezzos_after" src="https://cloud.githubusercontent.com/assets/542140/12066550/6d0cd25e-afe1-11e5-9bf8-7d38afe8b503.png">

I realise you might want to go in a totally different direction, but I thought I'd at least offer up some suggestions in case they you liked them. No hard feelings whatsoever if you don't!

Thanks again, and have a calm and casual New Year.

![thumbsup](https://cloud.githubusercontent.com/assets/542140/12066558/9be53e40-afe1-11e5-9772-8c5c28455b03.gif)
